### PR TITLE
Allow usernames with uppercase letters

### DIFF
--- a/custom_components/openid/views.py
+++ b/custom_components/openid/views.py
@@ -147,7 +147,7 @@ class OpenIDCallbackView(HomeAssistantView):
         user: User = None
         for u in users:
             for cred in u.credentials:
-                if cred.data.get("username") and cred.data.get("username").lower() == username.lower():
+                if cred.data.get("username").lower() == username.lower():
                     user = u
                     break
 


### PR DESCRIPTION
Fixed implementation for allowing usernames with uppercase letters. The "cred.data.get("username") and" still stops usernames with uppercase letters.