### PR TITLE
Fix #49 Broken login 

### DIFF
--- a/custom_components/openid/__init__.py
+++ b/custom_components/openid/__init__.py
@@ -177,6 +177,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     consent_template = await asyncio.to_thread(consent_path.read_text, encoding="utf-8")
     hass.data[DOMAIN]["consent_template"] = consent_template
 
+    # Preload error screen template
+    error_path = Path(__file__).parent / "error_template.html"
+    error_template = await asyncio.to_thread(error_path.read_text, encoding="utf-8")
+    hass.data[DOMAIN]["error_template"] = error_template
+
     # Serve the custom frontend JS that hooks into the login dialog
     await hass.http.async_register_static_paths(
         [

--- a/custom_components/openid/error_template.html
+++ b/custom_components/openid/error_template.html
@@ -1,0 +1,1 @@
+<html><body><script>localStorage.setItem('alertType', '${alert_type}');localStorage.setItem('alertMessage', '${alert_message}');window.location.href = '${redirect_url}';</script><h1>${alert_type}</h1><p>${alert_message}</p><p>Redirecting to ${redirect_url}...</p><p><a href='${redirect_url}'>Click here if not redirected</a></p></body></html>

--- a/custom_components/openid/manifest.json
+++ b/custom_components/openid/manifest.json
@@ -12,5 +12,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/cavefire/hass-openid/issues",
   "requirements": [],
-  "version": "1.1.6"
+  "version": "1.2.1"
 }

--- a/custom_components/openid/user_helper.py
+++ b/custom_components/openid/user_helper.py
@@ -1,0 +1,78 @@
+"""User management helpers for OpenID Connect integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.auth.models import User
+from homeassistant.components.person import DOMAIN as PERSON_DOMAIN, async_create_person
+from homeassistant.core import HomeAssistant
+from homeassistant.util import slugify
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_ensure_person_for_user(
+    hass: HomeAssistant, user: User, credential_data: dict
+) -> None:
+    """Create a person entry for the user if needed."""
+    if PERSON_DOMAIN not in hass.data:
+        _LOGGER.debug("Person component not loaded; skipping person creation")
+        return
+
+    _, storage_collection, _ = hass.data[PERSON_DOMAIN]
+    items = storage_collection.async_items()
+
+    if any(item.get("user_id") == user.id for item in items):
+        return
+
+    candidate_name = (
+        credential_data.get("name")
+        or credential_data.get("preferred_username")
+        or credential_data.get("username")
+        or user.name
+    )
+
+    if candidate_name:
+        slug_candidate = slugify(candidate_name)
+        for item in items:
+            item_name = item.get("name")
+            item_id = item.get("id")
+            if (
+                isinstance(item_name, str)
+                and item_name.lower() == candidate_name.lower()
+            ) or (
+                slug_candidate
+                and isinstance(item_id, str)
+                and item_id == slug_candidate
+            ):
+                if item.get("user_id") != user.id:
+                    await storage_collection.async_update_item(
+                        item["id"],
+                        {"user_id": user.id},
+                    )
+                return
+
+    person_name = candidate_name or user.id
+
+    try:
+        await async_create_person(hass, person_name, user_id=user.id)
+    except ValueError as err:
+        _LOGGER.warning("Unable to create person for user %s: %s", user.id, err)
+
+
+async def async_find_user_by_username(hass: HomeAssistant, username: str) -> User | None:
+    """Return existing user matching username if available."""
+    username_lower = username.lower()
+    for candidate in await hass.auth.async_get_users():
+        if candidate.name and candidate.name.lower() == username_lower:
+            return candidate
+
+        for existing_credentials in candidate.credentials:
+            stored_username = existing_credentials.data.get("username")
+            if (
+                isinstance(stored_username, str)
+                and stored_username.lower() == username_lower
+            ):
+                return candidate
+
+    return None

--- a/custom_components/openid/views.py
+++ b/custom_components/openid/views.py
@@ -65,7 +65,6 @@ class OpenIDAuthorizeView(HomeAssistantView):
         _LOGGER.debug("OpenIDAuthorizeView full URL: %s", request.url)
         # Check if we should show consent screen
         should_show_consent = (
-        should_show_consent = (
             self.hass.data[DOMAIN].get(CONF_BLOCK_LOGIN, False)
             and params.get("client_id") is not None
             and not self._is_own_instance(request, params.get("redirect_uri"))
@@ -237,7 +236,6 @@ class OpenIDConsentView(HomeAssistantView):
         _LOGGER.debug("Storing params under state %s: %s", state, dict(original_params))
 
         query = {
-            "response_type": "code",
             "response_type": "code",
             "client_id": self.hass.data[DOMAIN][CONF_CLIENT_ID],
             "redirect_uri": redirect_uri,


### PR DESCRIPTION
This PR introduces fix #49 with improper configuration loading - `view.py` used static configuration URLs instead of loading them from global configuration url.

Also added some cleanup.