### PR TITLE
Fix UnboundLocalError for headers when use_auth_header is false

### DIFF
--- a/custom_components/openid/oauth_helper.py
+++ b/custom_components/openid/oauth_helper.py
@@ -30,14 +30,12 @@ async def exchange_code_for_token(
         "redirect_uri": redirect_uri,
     }
 
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+
     if use_header_auth:
         credentials = f"{client_id}:{client_secret}"
         encoded_credentials = b64encode(credentials.encode("utf-8")).decode("utf-8")
-
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Authorization": f"Basic {encoded_credentials}",
-        }
+        headers["Authorization"] = f"Basic {encoded_credentials}"
     else:
         _LOGGER.warning(
             "Using client id and secret in request body might expose them, when your IdP logging is wrongly configured. Use with caution"


### PR DESCRIPTION
## Summary

When `use_auth_header` is set to `false`, `exchange_code_for_token()` in `oauth_helper.py` raises an `UnboundLocalError` because the `headers` variable is only defined inside the `if use_header_auth:` branch but referenced unconditionally by `session.post()`.

This moves the `headers` initialization before the `if/else` so it is always defined, and the `if` branch appends the `Authorization` header.

**Error:**
```
File "/config/custom_components/openid/oauth_helper.py", line 49, in exchange_code_for_token
    async with session.post(token_url, data=data, headers=headers) as resp:
UnboundLocalError: cannot access local variable 'headers' where it is not associated with a value
```

**Steps to reproduce:**
1. Set `use_auth_header: false` in `configuration.yaml` (needed for IdPs like Authelia that use `client_secret_post`)
2. Attempt SSO login
3. Token exchange fails with `UnboundLocalError`

## Test plan
- [x] Tested with Authelia (`token_endpoint_auth_method: client_secret_post`) + `use_auth_header: false` — full OIDC login flow completes successfully